### PR TITLE
Thirdperson improvement and menu pagination adjusted

### DIFF
--- a/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
@@ -1139,38 +1139,26 @@ public void LMC_OnClientModelApplied(int iClient, int iEntity, const char sModel
 		LMC_L4D2_SetTransmit(iClient, iEntity);
 }
 
-/**
- * Sets the view to thirdperson mode for a while.
- *
- * @param int	Client index.
- * @noreturn
- */
+
 void SetExternalView(int iClient)
 {
 	if(g_fThirdPersonTime < 0.5)// best time any lower is kinda pointless
 		return;
 	
 	float fCurrentTPtime = GetForcedThirdPerson(iClient);
-	if(fCurrentTPtime == SILVERS_THIRDPERSON_PLUGIN_TIME)// i dislike this method but if it helps not break plugins it is fine, maybe should we submit changes to silvers about those plugins, it is kinda hacky?
-		return;
-	
 	float fTime = GetGameTime();
 	if(fCurrentTPtime > (fTime + g_fThirdPersonTime))
 		return;
 	
-	if(fCurrentTPtime > fTime - 2.5)//helps to prevent a strange rare bug with models that include particles(e.g. witch) model spamming just about to go back to firstperson, causing stuff to not render correctly (Could be only me) this seems to be client bug.
-		return;
+	if(fCurrentTPtime < fTime + 0.5)
+		if(fCurrentTPtime > fTime - 1.0)//helps to prevent a strange rare bug with models that include particles(e.g. witch) model spamming just about to go back to firstperson, causing stuff to not render correctly (Could be only me) this seems to be client bug, this only seems to happen on maps with modded func_precipitation.
+			return;
 	
 	SetEntPropFloat(iClient, Prop_Send, "m_TimeForceExternalView", fTime + g_fThirdPersonTime);
 }
 
-/**
- * Validates if the client has the thirdperson view active.
- *
- * @param	int		Client index.
- * @return	float	Current forced view time
- */
+
 float GetForcedThirdPerson(int iClient)
 {
-	return GetEntPropFloat(iClient, Prop_Send, "m_TimeForceExternalView"); //NOTE:Silvers Survivor Thirdperson plugin sets time to 99999.3
+	return GetEntPropFloat(iClient, Prop_Send, "m_TimeForceExternalView");
 }

--- a/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
@@ -16,7 +16,7 @@
 
 
 #define PLUGIN_NAME "LMC_L4D2_Menu_Choosing"
-#define PLUGIN_VERSION "1.0.5"
+#define PLUGIN_VERSION "1.0.6"
 
 //change me to whatever flag you want
 #define COMMAND_ACCESS ADMFLAG_CHAT
@@ -227,7 +227,7 @@ public void OnPluginStart()
 	hCvar_AdminOnlyModel = CreateConVar("lmc_adminonly", "0", "Allow admins to only change models? (1 = true) NOTE: this will disable announcement to player who join. ((#define COMMAND_ACCESS ADMFLAG_CHAT) change to w/o flag you want or (Use override file))", FCVAR_NOTIFY, true, 0.0, true, 1.0);
 	hCvar_AnnounceDelay = CreateConVar("lmc_announcedelay", "15.0", "Delay On which a message is displayed for !lmc command", FCVAR_NOTIFY, true, 1.0, true, 360.0);
 	hCvar_AnnounceMode = CreateConVar("lmc_announcemode", "1", "Display Mode for !lmc command (0 = off, 1 = Print to chat, 2 = Center text, 3 = Director Hint)", FCVAR_NOTIFY, true, 0.0, true, 3.0);
-	hCvar_ThirdPersonTime = CreateConVar("lmc_thirdpersontime", "2.0", "How long (in seconds) the client will be in thirdperson view after selecting a model from !lmc command. (0 = off)", FCVAR_NOTIFY, true, 0.0, true, 360.0);
+	hCvar_ThirdPersonTime = CreateConVar("lmc_thirdpersontime", "0.0", "How long (in seconds) the client will be in thirdperson view after selecting a model from !lmc command. (0.5 < = off)", FCVAR_NOTIFY, true, 0.0, true, 360.0);
 	HookConVarChange(hCvar_AdminOnlyModel, eConvarChanged);
 	HookConVarChange(hCvar_AnnounceDelay, eConvarChanged);
 	HookConVarChange(hCvar_AnnounceMode, eConvarChanged);

--- a/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
@@ -199,6 +199,8 @@ static int iSavedModel[MAXPLAYERS+1] = {0, ...};
 static bool bAutoApplyMsg[MAXPLAYERS+1];
 static bool bAutoBlockedMsg[MAXPLAYERS+1][9];
 
+static int iCurrentPage[MAXPLAYERS+1];
+
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	if(GetEngineVersion() != Engine_Left4Dead2 )
@@ -234,7 +236,7 @@ public void OnPluginStart()
 	CvarsChanged();
 
 	hCookie_LmcCookie = RegClientCookie("lmc_cookie", "", CookieAccess_Protected);
-	RegConsoleCmd("sm_lmc", ShowMenu, "Brings up a menu to select a client's model");
+	RegConsoleCmd("sm_lmc", ShowMenuCmd, "Brings up a menu to select a client's model");
 
 	HookEvent("player_spawn", ePlayerSpawn);
 }
@@ -405,7 +407,11 @@ public void NextFrame(int iUserID)
 	ModelIndex(iClient, iSavedModel[iClient], false);
 }
 
-
+public Action ShowMenuCmd(int iClient, int iArgs)
+{
+	iCurrentPage[iClient] = 0;
+	ShowMenu(iClient, iArgs);
+}
 
 /*borrowed some code from csm*/
 public Action ShowMenu(int iClient, int iArgs)
@@ -481,7 +487,8 @@ public Action ShowMenu(int iClient, int iArgs)
 			AddMenuItem(hMenu, "25", "Tank DLC");
 	}
 	SetMenuExitButton(hMenu, true);
-	DisplayMenu(hMenu, iClient, 15);
+	//DisplayMenu(hMenu, iClient, 15);
+	DisplayMenuAtItem(hMenu, iClient, iCurrentPage[iClient], 15);
 	return Plugin_Continue;
 }
 
@@ -494,11 +501,12 @@ public int CharMenu(Handle hMenu, MenuAction action, int param1, int param2)
 			char sItem[4];
 			GetMenuItem(hMenu, param2, sItem, sizeof(sItem));
 			ModelIndex(param1, StringToInt(sItem), true);
+			iCurrentPage[param1] = GetMenuSelectionPosition();
 			ShowMenu(param1, 0);
 		}
 		case MenuAction_Cancel:
 		{
-
+			iCurrentPage[param1] = 0;
 		}
 		case MenuAction_End:
 		{
@@ -1097,6 +1105,7 @@ public void OnClientDisconnect(int iClient)
 		IntToString(iSavedModel[iClient], sCookie, sizeof(sCookie));
 		SetClientCookie(iClient, hCookie_LmcCookie, sCookie);
 	}
+	iCurrentPage[iClient] = 0;
 	bAutoApplyMsg[iClient] = true;//1.4
 	for(int i = 0; i < sizeof(bAutoBlockedMsg[]); i++)//1.4
 		bAutoBlockedMsg[iClient][i] = true;


### PR DESCRIPTION
Added thirdperson view after selecting a model from !lmc command
+New cvar lmc_thirdpersontime (default 2.0)

Menu pagination now stays after selecting a model from !lmc command
+New client variable iCurrentPage

I'm not pulling the .smx files, just the source (.sp).