### PR TITLE
Small changes

### DIFF
--- a/addons/sourcemod/scripting/LMC_L4D1_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D1_Menu_Choosing.sp
@@ -1,5 +1,5 @@
-/*  
-*    LMC_L4D1_Menu_Choosing - Allows you to use most models with Most characters in L4D-1/2
+/*
+*    LMC_L4D1_Menu_Choosing - Allows humans to choose LMC model with cookiesaving
 *    Copyright (C) 2019  LuxLuma		acceliacat@gmail.com
 *
 *    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 *    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
- 
+
 #pragma semicolon 1
 #include <sourcemod>
 #include <sdktools>
@@ -26,8 +26,8 @@
 #undef REQUIRE_EXTENSIONS
 
 #define REQUIRE_PLUGIN
-#include <LMCL4D1SetTransmit>
 #include <LMCCore>
+#include <LMCL4D1SetTransmit>
 
 #undef REQUIRE_PLUGIN
 
@@ -183,7 +183,7 @@ public void OnPluginStart()
 
 	hCvar_AdminOnlyModel = CreateConVar("lmc_adminonly", "0", "Allow admins to only change models? (1 = true) NOTE: this will disable announcement to player who join. ((#define COMMAND_ACCESS ADMFLAG_CHAT) change to w/o flag you want or (Use override file))", FCVAR_NOTIFY, true, 0.0, true, 1.0);
 	hCvar_AnnounceDelay = CreateConVar("lmc_announcedelay", "15.0", "Delay On which a message is displayed for !lmc command", FCVAR_NOTIFY, true, 1.0, true, 360.0);
-	hCvar_AnnounceMode = CreateConVar("lmc_announcemode", "1", "Display Mode for !lmc command (0 = off, 1 = Print to chat, 2 = Center text)", FCVAR_NOTIFY, true, 0.0, true, 2.0);
+	hCvar_AnnounceMode = CreateConVar("lmc_announcemode", "1", "Display Mode for !lmc command (0 = off, 1 = Print to chat, 2 = Hint text)", FCVAR_NOTIFY, true, 0.0, true, 2.0);
 	HookConVarChange(hCvar_AdminOnlyModel, eConvarChanged);
 	HookConVarChange(hCvar_AnnounceDelay, eConvarChanged);
 	HookConVarChange(hCvar_AnnounceMode, eConvarChanged);
@@ -267,10 +267,10 @@ public void OnMapStart()
 		int i;
 		for(i = 0; i < HUMAN_MODEL_PATH_SIZE; i++)
 			PrecacheModel(sHumanPaths[i], true);
-		
+
 		for(i = 0; i < SPECIAL_MODEL_PATH_SIZE; i++)
 			PrecacheModel(sSpecialPaths[i], true);
-		
+
 		for(i = 0; i < COMMON_MODEL_PATH_SIZE; i++)
 			PrecacheModel(sCommonPaths[i], true);
 	}
@@ -354,7 +354,7 @@ public void ePlayerBotReplace(Handle hEvent, const char[] sEventName, bool bDont
 {
 	int iClient = GetClientOfUserId(GetEventInt(hEvent, "player"));
 	int iBot = GetClientOfUserId(GetEventInt(hEvent, "bot"));
-	
+
 	if(iBot < 1 || iBot > MaxClients)
 		return;
 
@@ -486,7 +486,7 @@ public Action ShowMenu(int iClient, int iArgs)
 			AddMenuItem(hMenu, "13", Translate(iClient, "%t", "Tank DLC"));
 	}
 	SetMenuExitButton(hMenu, true);
-	
+
 	DisplayMenuAtItem(hMenu, iClient, iCurrentPage[iClient], 15);
 	return Plugin_Continue;
 }
@@ -576,7 +576,7 @@ void ModelIndex(int iClient, int iCaseNum, bool bUsingMenu=false)
 						if(!bUsingMenu && !bAutoBlockedMsg[iClient][3])
 							return;
 
-						CPrintToChat(iClient, "%t", ""); // "\x04[LMC] \x03Server Has Disabled Models for \x04Tank");
+						CPrintToChat(iClient, "%t", "Disabled_Models_Tank"); // "\x04[LMC] \x03Server Has Disabled Models for \x04Tank");
 						bAutoBlockedMsg[iClient][3] = false;
 						return;
 					}
@@ -590,7 +590,7 @@ void ModelIndex(int iClient, int iCaseNum, bool bUsingMenu=false)
 				if(!bUsingMenu && !bAutoBlockedMsg[iClient][4])
 					return;
 
-				CPrintToChat(iClient, "%t", "Disabled_Models_Tank"); // "\x04[LMC] \x03Server Has Disabled Models for \x04Survivors");
+				CPrintToChat(iClient, "%t", "Disabled_Models_Survivors"); // "\x04[LMC] \x03Server Has Disabled Models for \x04Survivors");
 				bAutoBlockedMsg[iClient][4] = false;
 				return;
 			}
@@ -788,7 +788,7 @@ public Action iClientInfo(Handle hTimer, any iUserID)
 			CPrintToChat(iClient, "%t", "Change_Model_Help_Chat"); // "\x04[LMC] \x03To Change Model use chat Command \x04!lmc\x03");
 			EmitSoundToClient(iClient, sJoinSound, SOUND_FROM_PLAYER, SNDCHAN_STATIC);
 		}
-		case 2: PrintHintText(iClient, "%t", "Change_Model_Help_Hint"); // "[LMC] To Change Model use chat Command !lmc");
+		case 2: PrintHintText(iClient, "%t", TranslateNoColor(iClient, "%t", "Change_Model_Help_Chat")); // "[LMC] To Change Model use chat Command !lmc");
 	}
 	return Plugin_Stop;
 }
@@ -880,7 +880,7 @@ public void OnClientCookiesCached(int iClient)
 	if(!IsClientInGame(iClient) || !IsPlayerAlive(iClient))
 		return;
 
-	if(g_bAdminOnly && !CheckCommandAccess(iClient, "sm_lmc", COMMAND_ACCESS, true))
+	if(g_bAdminOnly && !CheckCommandAccess(iClient, "sm_lmc", COMMAND_ACCESS))
 			return;
 
 	ModelIndex(iClient, iSavedModel[iClient], false);

--- a/addons/sourcemod/scripting/LMC_L4D1_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D1_Menu_Choosing.sp
@@ -788,7 +788,7 @@ public Action iClientInfo(Handle hTimer, any iUserID)
 			CPrintToChat(iClient, "%t", "Change_Model_Help_Chat"); // "\x04[LMC] \x03To Change Model use chat Command \x04!lmc\x03");
 			EmitSoundToClient(iClient, sJoinSound, SOUND_FROM_PLAYER, SNDCHAN_STATIC);
 		}
-		case 2: PrintHintText(iClient, "%t", TranslateNoColor(iClient, "%t", "Change_Model_Help_Chat")); // "[LMC] To Change Model use chat Command !lmc");
+		case 2: PrintHintText(iClient, "%s", TranslateNoColor(iClient, "%t", "Change_Model_Help_Chat")); // "[LMC] To Change Model use chat Command !lmc");
 	}
 	return Plugin_Stop;
 }

--- a/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
@@ -1,4 +1,4 @@
-/*  
+/*
 *    LMC_L4D2_Menu_Choosing - Allows humans to choose LMC model with cookiesaving
 *    Copyright (C) 2019  LuxLuma		acceliacat@gmail.com
 *
@@ -221,7 +221,7 @@ static int iCurrentPage[MAXPLAYERS+1];
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	if(GetEngineVersion() != Engine_Left4Dead2 )
+	if(GetEngineVersion() != Engine_Left4Dead2)
 	{
 		strcopy(error, err_max, "Plugin only supports Left 4 Dead 2");
 		return APLRes_SilentFailure;
@@ -423,7 +423,7 @@ public void ePlayerBotReplace(Handle hEvent, const char[] sEventName, bool bDont
 {
 	int iClient = GetClientOfUserId(GetEventInt(hEvent, "player"));
 	int iBot = GetClientOfUserId(GetEventInt(hEvent, "bot"));
-	
+
 	if(iBot < 1 || iBot > MaxClients)
 		return;
 
@@ -579,7 +579,7 @@ public Action ShowMenu(int iClient, int iArgs)
 			AddMenuItem(hMenu, "25", Translate(iClient, "%t", "Tank DLC"));
 	}
 	SetMenuExitButton(hMenu, true);
-	//DisplayMenu(hMenu, iClient, 15);
+
 	DisplayMenuAtItem(hMenu, iClient, iCurrentPage[iClient], 15);
 	return Plugin_Continue;
 }
@@ -1095,13 +1095,13 @@ public Action iClientInfo(Handle hTimer, any iUserID)
 			int iEntity = CreateEntityByName("env_instructor_hint");
 			if(iEntity < 1)
 				return Plugin_Stop;
-				
+
 			char sValues[64];
-			
+
 			FormatEx(sValues, sizeof(sValues), "hint%d", iClient);
 			DispatchKeyValue(iClient, "targetname", sValues);
 			DispatchKeyValue(iEntity, "hint_target", sValues);
-			
+
 			Format(sValues, sizeof(sValues), "10");
 			DispatchKeyValue(iEntity, "hint_timeout", sValues);
 			DispatchKeyValue(iEntity, "hint_range", "100");
@@ -1111,7 +1111,7 @@ public Action iClientInfo(Handle hTimer, any iUserID)
 			DispatchKeyValue(iEntity, "hint_color", sValues);
 			DispatchSpawn(iEntity);
 			AcceptEntityInput(iEntity, "ShowHint", iClient);
-			
+
 			SetVariantString("OnUser1 !self:Kill::6:1");
 			AcceptEntityInput(iEntity, "AddOutput");
 			AcceptEntityInput(iEntity, "FireUser1");
@@ -1236,16 +1236,16 @@ void SetExternalView(int iClient)
 {
 	if(g_fThirdPersonTime < 0.5)// best time any lower is kinda pointless
 		return;
-	
+
 	float fCurrentTPtime = GetForcedThirdPerson(iClient);
 	float fTime = GetGameTime();
 	if(fCurrentTPtime > (fTime + g_fThirdPersonTime))
 		return;
-	
+
 	if(fCurrentTPtime < fTime + 0.5)
 		if(fCurrentTPtime > fTime - 1.0)//helps to prevent a strange rare bug with models that include particles(e.g. witch) model spamming just about to go back to firstperson, causing stuff to not render correctly (Could be only me) this seems to be client bug, this only seems to happen on maps with modded func_precipitation.
 			return;
-	
+
 	SetEntPropFloat(iClient, Prop_Send, "m_TimeForceExternalView", fTime + g_fThirdPersonTime);
 }
 

--- a/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
+++ b/addons/sourcemod/scripting/LMC_L4D2_Menu_Choosing.sp
@@ -1089,7 +1089,7 @@ public Action iClientInfo(Handle hTimer, any iUserID)
 			CPrintToChat(iClient, "%t", "Change_Model_Help_Chat"); // "\x04[LMC] \x03To Change Model use chat Command \x04!lmc\x03");
 			EmitSoundToClient(iClient, sJoinSound, SOUND_FROM_PLAYER, SNDCHAN_STATIC);
 		}
-		case 2: PrintHintText(iClient, "%t", TranslateNoColor(iClient, "%t", "Change_Model_Help_Chat")); // "[LMC] To Change Model use chat Command !lmc");
+		case 2: PrintHintText(iClient, "%s", TranslateNoColor(iClient, "%t", "Change_Model_Help_Chat")); // "[LMC] To Change Model use chat Command !lmc");
 		case 3:
 		{
 			int iEntity = CreateEntityByName("env_instructor_hint");

--- a/addons/sourcemod/translations/lmc.phrases.txt
+++ b/addons/sourcemod/translations/lmc.phrases.txt
@@ -1,9 +1,9 @@
 /*
 	Following named colors are supported:
-	 - {white}	(use instead of \x01 )
-	 - {cyan}	(use instead of \x03 )
-	 - {orange}	(use instead of \x04 )
-	 - {green}	(use instead of \x05 )
+	 - {white}	(use instead of \x01)
+	 - {cyan}	(use instead of \x03)
+	 - {orange}	(use instead of \x04)
+	 - {green}	(use instead of \x05)
 */
 
 "Phrases"
@@ -37,7 +37,6 @@
 		"fr"		"{orange}[LMC] {cyan}Changeur de Modèle est disponible uniquement pour les admins."
 		"pl"		"{orange}[LMC] {cyan}Zmiana Modeli dostepna tylko dla adminów."
 		"pt"		"{orange}[LMC] {cyan}A alteração de modelo é apenas para administradores."
-
 	}
 	"Alive only"
 	{
@@ -623,7 +622,6 @@
 		"fr"		"{orange}[LMC] {cyan}Le modèle est {orange}Sorcière Mariée"
 		"pl"		"{orange}[LMC] {cyan}Model jest {orange}Panna Mloda Wiedzma"
 		"pt"		"{orange}[LMC] {cyan}Alterado modelo para {orange}Witch (noiva)"
-
 	}
 	"Model_Boomer"
 	{
@@ -939,7 +937,6 @@
 		"fr"		"{orange}[LMC] {cyan}Le modèle est {orange}Tank du DLC"
 		"pl"		"{orange}[LMC] {cyan}Model jest {orange}Tank DLC"
 		"pt"		"{orange}[LMC] {cyan}Alterado modelo para {orange}Tank DLC"
-
 	}
 	"Change_Model_Help_Chat"
 	{
@@ -955,20 +952,5 @@
 		"fr"		"{orange}[LMC] {cyan}Pour changer le modèle, utilisez la commande chat{orange}!lmc"
 		"pl"		"{orange}[LMC] {cyan}Zeby zmienic swój model, w czacie wpisz {orange}!lmc"
 		"pt"		"{orange}[LMC] {cyan}Para mudar o modelo do personagem use o comando {orange}!lmc no chat"
-	}
-	"Change_Model_Help_Hint"
-	{
-		"en"		"[LMC] To Change Model use chat Command !lmc"
-		"chi"		"[LMC] 使用!lmc来选择皮肤模型"
-		"ru"		"[LMC] Для смены модели введите в чат !lmc"
-		"ua"		"[LMC] Для зміни моделі введіть у чат !lmc"
-		"sv"		"[LMC] För att ändra modell, använd chattkommandot !lmc"
-		"es"		"[LMC] Para cambiar el modelo use el Commando en el chat !lmc"
-		"hu"		"[LMC] Modell váltáshoz használd a chat parancsot !lmc"
-		"de"		"[LMC] Benutze den Chat-Befehl !lmc um dein Modell zu ändern"
-		"it"		"[LMC] Per Cambiare Modelle usa il Comando Chat !lmc"
-		"fr"		"[LMC] Pour changer le modèle, utilisez la commande chat !lmc"
-		"pl"		"[LMC] Zeby zmienic model, w czacie wpisz !lmc"
-		"pt"		"[LMC] Para mudar o modelo do personagem use o comando !lmc no chat"
 	}
 }


### PR DESCRIPTION
*LMC_L4D1_Menu_Choosing
	- Fixed plugin description on license (same as plugin description, like the others files)
	- Ported description fix on L4D1 for lmc_announcemode cvar (Center Text -> Hint Text)
	- Fixed missing translation string on Tank
	- Fixed incorrect translation string on Survivors
	- Translation -> Replaced hint string with TranslateNoColor chat string
		> Now Change_Model_Help_Hint can be removed from translation files
	- Removed last parameter from CheckCommandAccess (based on the previous commit => Use cmd string for access)
	- Fixed PrintHintText string parameter.

*LMC_L4D2_Menu_Choosing
	- Removed old display menu comment.
	- Fixed PrintHintText string parameter.

*lmc.phrases
	- Removed phrase "Change_Model_Help_Hint" (no more needed)
	- Removed spaces/extra line breaks